### PR TITLE
Fixed the image container

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -235,7 +235,19 @@ img{
   bottom: 0;
   width: 295px;
 }
-
+/*Media query for reducing z-index and sending the behind text for different screen size*/
+@media(max-width:1200px) and (min-width:900px){
+    .home__img{
+        z-index:-1;
+        bottom:0;
+    }
+}
+@media(max-width:900px){
+    .home__img{
+        z-index:-1;
+        bottom:-30px;
+    }
+}
 /*BUTTONS*/
 .button{
   display: inline-block;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -235,7 +235,7 @@ img{
   bottom: 0;
   width: 295px;
 }
-/*Media query for reducing z-index and sending the behind text for different screen size*/
+/*Media query for reducing z-index and sending the image container behind text for different screen size*/
 @media(max-width:1200px) and (min-width:900px){
     .home__img{
         z-index:-1;


### PR DESCRIPTION
**BUG**
The image container _home__img_ caused some issues with text.
In small-screen devices, the image hid the text and contact us button.
**FIX**
Simple **@media** query with z-index fixed the issue.

**BEFORE**
![image](https://user-images.githubusercontent.com/35869741/94986737-a5ac7f00-0550-11eb-8ed0-d0dba724bab4.png)

**AFTER**
![image](https://user-images.githubusercontent.com/35869741/94986759-d55b8700-0550-11eb-8466-58e73eef4186.png)

Great work BTW @bigyanic  :) +1: :100: 